### PR TITLE
Update encoder distances Robot.java

### DIFF
--- a/2018---The REAL First Power Up/src/org/usfirst/frc/team2586/robot/Robot.java
+++ b/2018---The REAL First Power Up/src/org/usfirst/frc/team2586/robot/Robot.java
@@ -119,9 +119,12 @@ public class Robot extends TimedRobot {
 		leftEnc = new Encoder(0, 1);
 		rightEnc = new Encoder(2, 3);
 
-		leftEnc.setDistancePerPulse(10.0 / 10.0); // [Inches/Pulses]
-		rightEnc.setDistancePerPulse(10.0 / 10.0); // [Inches/Pulses]
-
+		leftEnc.setDistancePerPulse(18.85 / 360.0); // [Inches/Pulses]
+		rightEnc.setDistancePerPulse(18.85 / 360.0); // [Inches/Pulses]
+		// since we do not know the if the decoding is by 1x, 2x, or 4x, I have inputted the x1 value
+		// the value for x2 is 720 pulses per revolution and the value for x4 is 1440 pulses per revolution
+		// 18.85 inches is the value of one rotation, 1x is 0.052 inches per pulse, 2x is 0.026 inches per pulse, and 4x is 0.013 inches per pulse
+		
 		// Gyro
 		gyro = new ADIS16448_IMU();
 		gyro.calibrate();


### PR DESCRIPTION
I've just added what SHOULD be the correct ratio of inches to pulses for Horatio's encoders. If my values are off then we have a different encoding values (I assumed we have 1x encoding as it's not marked anywhere on the encoders themselves). If I assumed wrong, I also commented in the values for the other encoder counting methods (2x and 4x). If this doesn't work, we could just as easily give one of the other values a shot.